### PR TITLE
Fix  "Out of depth map range error"

### DIFF
--- a/template_manager_script.py
+++ b/template_manager_script.py
@@ -164,7 +164,6 @@ while True:
             if is_in_image(sqn_xyz_ref_x, sqn_xyz_ref_y):
                 xyz_ref = 1
         if xyz_ref == 0 and is_visible(right_shoulder) and is_visible(left_shoulder):
-            xyz_ref = 2
             kp1 = right_shoulder
             kp2 = left_shoulder
             rrn_xyz_ref_x = (lms[5*kp1] + lms[5*kp2]) / 512 # 512 = 256*2 (256 to normalizing, 2 for the mean)


### PR DESCRIPTION
Hi,
When both the shoulder and the hip are not in the image, there is an error in depthai with "Out of depth map range error" because the checking of the shoulder inside the image is ignored because `xyz_ref = 2` is set anyway.

Not sure if it is intentional. If it is, please close and ignore this PR.



