### PR TITLE
Fix deprecated numpy type issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<1.24.0
+numpy < 1.24.0
 opencv-python >= 4.5.1.48
 open3d
 depthai >= 2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy<1.24.0
 opencv-python >= 4.5.1.48
 open3d
 depthai >= 2.10


### PR DESCRIPTION
# Summary 
The code base makes use of np.int, however np.int has been deprecated since 1.24.0 of Numpy. The current version of requirements.txt does not specify a Numpy version causing pip to pull a version of Numpy that does not support np.int. Several errors are thrown when running blocking the demo.py from working. I addressed this by updating the requirements.txt to obtain a Numpy version less than 1.24.0.